### PR TITLE
Show only essential fields within popups

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -8,11 +8,12 @@ var L = require('leaflet'),
         fieldSeparator: '|',
         firstLineTitles: true,
         onEachFeature: function (feature, layer) {
-            var popup = '', title;
-            for (var indice in feature.properties) {
-                title = indice;
-                popup += '<b>'+title+'</b><br />'+feature.properties[indice]+'<br />';
-            }
+            var properties = feature.properties,
+                popup = 'Batalhão responsável: '.bold() + properties.batalho + '<br />' +
+                        'Despacho: '.bold() + properties.despacho + '<br />' +
+                        'Conclusão: '.bold() + properties.concluso + '<br />' +
+                         '<br />' +
+                         properties.observaes;
             layer.bindPopup(popup);
         },
         pointToLayer: function (feature, latlng) {


### PR DESCRIPTION
My first plan was change the approach from hundreds of popups to only one box that shows the details of the selected incident, but the time is up! For while, I've just removed some properties that was already plotted and some other that doesn't looks to relate with the goal of this [first milestone](https://github.com/NAMD/SegPub/milestones/Leaflet%20with%20incident%20filter).

It solves #6.
