### PR TITLE
Bugfix/fix endless load

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "leaflet.markercluster": "^0.4.0"
   },
   "devDependencies": {
-    "browserify": "^10.2.4",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.8.0",
     "grunt-cli": "^0.1.13",

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1,7 +1,7 @@
 var L = require('leaflet'),
     // https://cartodb.com/basemaps
     tileUrlPattern = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
-    cluster = new L.MarkerClusterGroup(),
+    cluster = require('leaflet.markercluster') && new L.MarkerClusterGroup(),
     mapa = L.map('mapaleaf', {
         attributionControl: false,
         zoomControl: false
@@ -29,7 +29,6 @@ var L = require('leaflet'),
     };
 
 require('leaflet-geocsv');
-require('leaflet.markercluster');
 
 function setInitialView(mapa){
     var initialView = [[-22.92, -43.22], 10];

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -34,10 +34,7 @@ require('leaflet.markercluster');
 function setInitialView(mapa){
     var initialView = [[-22.92, -43.22], 10];
     mapa.setView.apply(mapa, initialView);
-}
-
-setInitialView(mapa);
-
+}(mapa);
 
 L.tileLayer(tileUrlPattern, { maxZoom: 18 }).addTo(mapa);
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -28,6 +28,9 @@ var L = require('leaflet'),
         }
     };
 
+require('leaflet-geocsv');
+require('leaflet.markercluster');
+
 function setInitialView(mapa){
     var initialView = [[-22.92, -43.22], 10];
     mapa.setView.apply(mapa, initialView);
@@ -35,8 +38,6 @@ function setInitialView(mapa){
 
 setInitialView(mapa);
 
-require('leaflet-geocsv');
-require('leaflet.markercluster');
 
 L.tileLayer(tileUrlPattern, { maxZoom: 18 }).addTo(mapa);
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -19,7 +19,7 @@ var L = require('leaflet'),
             return L.marker(latlng, {
                 icon:L.icon({
                     iconUrl: '/images/iconmonstr-warning-2-icon.svg',
-                    iconSize: [30,30],
+                    iconSize: [30, 30],
                 })
             });
         }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -49,11 +49,11 @@ exports.plot = function (finalKind, from, to){
         loading = document.getElementById('loading'),
         ocorrencias = L.geoCsv(null, options);
 
+    cluster.clearLayers();
     loading.style.display = 'flex';
 
     d3.text(url).get().on('load', function(csv) {
         ocorrencias.addData(csv);
-        cluster.clearLayers();
         cluster.addLayer(ocorrencias);
         var bounds = cluster.getBounds();
         if(bounds.isValid()){

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1,4 +1,7 @@
 var L = require('leaflet'),
+    // https://cartodb.com/basemaps
+    tileUrlPattern = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+    cluster = new L.MarkerClusterGroup(),
     mapa = L.map('mapaleaf', {
         attributionControl: false,
         zoomControl: false
@@ -35,11 +38,8 @@ setInitialView(mapa);
 require('leaflet-geocsv');
 require('leaflet.markercluster');
 
-// https://cartodb.com/basemaps
-var tileUrlPattern = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
 L.tileLayer(tileUrlPattern, { maxZoom: 18 }).addTo(mapa);
 
-var cluster = new L.MarkerClusterGroup();
 mapa.addLayer(cluster);
 
 exports.plot = function (finalKind, from, to){

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2,7 +2,7 @@ var L = require('leaflet'),
     mapa = L.map('mapaleaf', {
         attributionControl: false,
         zoomControl: false
-    }).setView([-22.92,-43.22], 10),
+    }),
     options = {
         fieldSeparator: '|',
         firstLineTitles: true,
@@ -25,6 +25,12 @@ var L = require('leaflet'),
         }
     };
 
+function setInitialView(mapa){
+    var initialView = [[-22.92, -43.22], 10];
+    mapa.setView.apply(mapa, initialView);
+}
+
+setInitialView(mapa);
 
 require('leaflet-geocsv');
 require('leaflet.markercluster');
@@ -40,7 +46,7 @@ exports.plot = function (finalKind, from, to){
     var url = '/incidents?finalKind=' + finalKind +
                    '&from=' + from +
                    '&to=' + to,
-    loading = document.getElementById('loading'),
+        loading = document.getElementById('loading'),
         ocorrencias = L.geoCsv(null, options);
 
     loading.style.display = 'flex';
@@ -49,7 +55,12 @@ exports.plot = function (finalKind, from, to){
         ocorrencias.addData(csv);
         cluster.clearLayers();
         cluster.addLayer(ocorrencias);
-        mapa.fitBounds(cluster.getBounds());
+        var bounds = cluster.getBounds();
+        if(bounds.isValid()){
+            mapa.fitBounds(bounds);
+        }else{
+            setInitialView(mapa);
+        }
         loading.style.display = 'none';
     })
     .on('error', function(){


### PR DESCRIPTION
When a category has no incident in a given slice of time `cluster.getBounds()` returns an empty object, which breaks `.fitBounds()`.

I think it should be handled by Leaflet, but I've solved testing if the bounds are valid before passing it to fitBounds. 

Furthermore, I did some other small changes.